### PR TITLE
[노하은] 시간표 유형 선정 기능 추가 완료, 팀원들 데이터 추가 완료, 공대를 공학관으로 변경, 오류 해결

### DIFF
--- a/javacodes/src/Class.java
+++ b/javacodes/src/Class.java
@@ -10,7 +10,7 @@ class Class {
     int endH;           // 끝 시
     int endM;           // 끝 분
 
-    // 생성자 (오프라인 강의)
+    // 생성자 (오프라인 강의 & 시간이 정해진 원격/비대면 강의)
     public Class (Long classId, String className, String location, String weekday, int startH, int startM, int endH, int endM){
         this.id = classId;
         this.className = className;
@@ -22,7 +22,7 @@ class Class {
         this.endM = endM;
     }
 
-    // 생성자 (온라인 강의)
+    // 생성자 (시간이 정해지지 않은 원격/비대면 강의)
     public Class (Long classId, String className){
         this.id = classId;
         this.className = className;

--- a/javacodes/src/Main.java
+++ b/javacodes/src/Main.java
@@ -121,6 +121,7 @@ public class Main {
 //        System.out.println("모두 오후 수업인지 판별");
 //        for(Table t : data2) AllClassAlgo.allAfternoonAlgo(t);
 
+        // 이동난이도 해시맵 생성
         Map<List<String>, Move> moveDifficulty = new HashMap<>();
         moveDifficulty.put(Arrays.asList("학관", "학관"), new Move(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("학관", "ECC"), new Move(false, Difficulty.MEDIUM));
@@ -128,21 +129,34 @@ public class Main {
         moveDifficulty.put(Arrays.asList("ECC", "학관"), new Move(true, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("공대", "학관"), new Move(false, Difficulty.HIGH));
 
-        testData(data4, moveDifficulty);
+        // 스페셜 코멘트 해시맵 생성
+        Map<Long, SpecialComment> specialComments = makeSpecialComments();
+
+        // 채점 수행
+        testData(data4, moveDifficulty, specialComments);
     }
 
-    public static void testData(ArrayList<Table> data, Map<List<String>, Move> moveDifficulty){
+    /*
+    최종적으로 채점 작업을 수행하는 함수
+     */
+    public static void testData(ArrayList<Table> data, Map<List<String>, Move> moveDifficulty, Map<Long, SpecialComment> specialComments){
+        Long index = 1L;
+
         for(Table t : data){
+            System.out.println("================= " + index++ + "번 시간표 채점 시작 =================");
+
             ArrayList<Integer> good = new ArrayList<>();
             ArrayList<Integer> bad = new ArrayList<>();
             ArrayList<Integer> special = new ArrayList<>();
 
             int score = 60; // 기본 점수 60점 
 
-            System.out.println("========== algorithm test - 전체 ==========");
+            System.out.println();
+            System.out.println("--------------- algorithm test - 전체 ---------------");
             score += AllClassAlgo.allClassAlgo(t, good, bad, special);
-            System.out.println("");
-            System.out.println("========== algorithm test - 요일별 ==========");
+
+            System.out.println();
+            System.out.println("--------------- algorithm test - 요일별 ---------------");
             score += WeekdayAlgo.weekdayAlgo(t, moveDifficulty, good, bad, special);
 
             if (score < 0)
@@ -158,7 +172,16 @@ public class Main {
             System.out.println("bad: " + bad);
             System.out.println("special: " + special);
             System.out.println("총점: " + score);
-            System.out.println("===========================================");
+
+            System.out.println();
+            System.out.println("--------------- algorithm test - 유형 선정 ---------------");
+            // 시간표 유형 판별
+            System.out.println("이 시간표의 유형: " + TableTypeAlgo.tableTypeAlgo(special, specialComments));
+
+            System.out.println();
+            System.out.println();
+
+
         }
     }
 
@@ -1203,6 +1226,38 @@ public class Main {
 
         // 데이터리스트 리턴
         return result;
+    }
+
+    /*
+    이 아래는 스페셜 코멘트 데이터를 생성하여 Map에 넣는 함수
+     */
+    public static Map<Long, SpecialComment> makeSpecialComments () {
+        Map<Long, SpecialComment> specialComments = new HashMap<>();
+
+        // 한비 님이 부여하신 ID대로 코멘트 내용 채우기
+        String[] contents = new String[14];
+        contents[0] = "취미는 학교 다니기";
+        contents[1] = "등록금 뿌린 대로 거두자";
+        contents[2] = "이화 사이버 대학교";
+        contents[3] = "하나님의 축복이 끝이 없네";
+        contents[4] = "상여자 특) 점심 먹고 등교함";
+        contents[5] = "(충격) 6시 넘어서 수업 듣는 사람 (진짜 계심)";
+        contents[6] = "이대 지박령을 뵙습니다";
+        contents[7] = "퐁당퐁당 수업을 나누자";
+        contents[8] = "동에 번쩍 서에 번쩍";
+        contents[9] = "쉬는 시간에 치타가 되는 사람";
+        contents[10] = "이화사랑산악회";
+        contents[11] = "점심은 포기 못해";
+        contents[12] = "밥은 먹고 다니냐?";
+        contents[13] = "한 건물 지박령";
+
+        // 14개의 스페셜 코멘트를 Map에 모두 추가
+        for(Long i=0L; i<14; i++)
+            specialComments.put(i, new SpecialComment(i, contents[i.intValue()], i));
+        // 우선순위는 일단 ID와 동일하게 설정하였음
+
+        // 완성된 스페셜 코멘트 목록을 리턴
+        return specialComments;
     }
 
     /*

--- a/javacodes/src/Main.java
+++ b/javacodes/src/Main.java
@@ -83,6 +83,7 @@ public class Main {
 //        printTables(data4);
 //        printTables(data5);
 //        printTables(data6);
+        printTables(data7);
 
 //        System.out.println("========== algorithm test - 전체 ==========");
 //
@@ -125,18 +126,12 @@ public class Main {
 //        for(Table t : data2) AllClassAlgo.allAfternoonAlgo(t);
 
         // 이동난이도 해시맵 생성
-        Map<List<String>, Move> moveDifficulty = new HashMap<>();
-        moveDifficulty.put(Arrays.asList("학관", "학관"), new Move(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("학관", "ECC"), new Move(false, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("학관", "공학관"), new Move(true, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("ECC", "학관"), new Move(true, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("공학관", "학관"), new Move(false, Difficulty.HIGH));
-
+        Map<List<String>, Move> moveDifficulty = makeMoveDifficulties();
         // 스페셜 코멘트 해시맵 생성
         Map<Long, SpecialComment> specialComments = makeSpecialComments();
 
         // 채점 수행
-        testData(data4, moveDifficulty, specialComments);
+        testData(data7, moveDifficulty, specialComments);
     }
 
     /*
@@ -1244,27 +1239,410 @@ public class Main {
         temp = new Table(tableId);
 
         classId++;
-        temp.classList.add(new Class(classId, "인공지능", "공학관"));
-        temp.classList.add(hak.get(1));
-
-        temp.classList.add(hak.get(2));
-        temp.classList.add(hak.get(3));
-
-        temp.classList.add(hak.get(4));
-        temp.classList.add(hak.get(5));
-
-        temp.classList.add(hak.get(6));
-        temp.classList.add(hak.get(7));
-
-        temp.classList.add(hak.get(8));
-        temp.classList.add(hak.get(9));
-
-        temp.classList.add(hak.get(10));
-        temp.classList.add(hak.get(11));
+        temp.classList.add(new Class(classId, "인공지능", "공학관", "월", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인공지능", "공학관", "수", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "운영체제", "공학관", "월", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "운영체제", "공학관", "수", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "화", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "금", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "캡스톤디자인과창업프로젝트B", "공학관", "화", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "캡스톤디자인과창업프로젝트B", "공학관", "금", 14, 0, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "디지털논리설계", "공학관", "화", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "디지털논리설계", "공학관", "목", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "SW리더십과기업가정신세미나III", "공학관", "화", 17, 0, 18, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "목", 11, 30, 12, 0));
 
         temp = addClass(temp, temp.classList);
 
         result.add(temp);
+
+        // 시트 2 이소정
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "한국현대시와 삶읽기", "포스코관", "월", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "한국현대시와 삶읽기", "포스코관", "목", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "자료구조", "공학관", "월", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "자료구조", "공학관", "목", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "선형대수학1", "포스코관", "월", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "선형대수학1", "포스코관", "수", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "일반생물학", "종합과학관", "화", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "일반생물학", "종합과학관", "목", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "시스템sw및 실습", "공학관", "월", 17, 0, 18, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "시스템sw및 실습", "공학관", "목", 17, 0, 18, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "수", 11, 0, 12, 0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 3 최한비
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "일반생물학", "포스코관", "월", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "일반생물학", "포스코관", "목", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "기독교와세계", "학관", "월", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "기독교와세계", "학관", "수", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "일반물리학I", "종합과학관", "월", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "일반물리학I", "종합과학관", "수", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "일반물리학실험I", "종합과학관", "화", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "미분적분학", "포스코관", "화", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "미분적분학", "포스코관", "목", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "CollegeEnglish", "ECC", "화", 8, 0, 9, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "CollegeEnglish", "ECC", "목", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "호크마세미나", "원격/비대면", "화", 17, 0, 18, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "화", 9, 30, 10 ,0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 4 김민정
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "월", 10, 0, 10, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "UI디자인", "sk텔레콤관(정보관)", "월", 12, 30, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "컴퓨터알고리즘", "공학관", "월", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "컴퓨터알고리즘", "공학관", "수", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "캡스톤디자인과창업프로젝트B", "공학관", "화", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "캡스톤디자인과창업프로젝트B", "공학관", "금", 14, 0, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "수", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "금", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "오토마타및형식언어", "공학관", "수", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "오토마타및형식언어", "공학관", "금", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "K-MOOC:동물의행동"));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 5 오혜린
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "마케팅 조사", "신세계관", "월", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "마케팅 조사", "신세계관", "수", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "인적자원관리", "신세계관", "월", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "인적자원관리", "신세계관", "수", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "미시경제이론", "포스코관", "화", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "미시경제이론", "포스코관", "금", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "개인금융", "신세계관", "화", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "개인금융", "신세계관", "목", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "경영학원론", "신세계관", "수", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "경영학원론", "신세계관", "금", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "시장경제세미나", "포스코관", "수", 15, 30, 18, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "목", 11, 30, 12, 0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 6 권태영
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "월", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "목", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "운영체제", "공학관", "월", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "운영체제", "공학관", "수", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "데이터베이스", "공학관", "화", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "데이터베이스", "공학관", "목", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "컴퓨터알고리즘", "공학관", "화", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "컴퓨터알고리즘", "공학관", "목", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "SW리더십과기업가정신세미나", "공학관", "화", 17, 0, 18, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인물로본중국의역사", "포스코관", "수", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인물로본중국의역사", "포스코관", "금", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "목", 11, 30, 12, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "시장경제세미나", "포스코관", "목", 15, 30, 18, 30));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 7 차소연
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "화", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "정보통신공학", "공학관", "금", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인공지능", "공학관", "월", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인공지능", "공학관", "수", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "컴퓨터알고리즘", "공학관", "화", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "컴퓨터알고리즘", "공학관", "목", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "데이터베이스", "공학관", "화", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "데이터베이스", "공학관", "목", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "프로그래밍을위한컴퓨팅적사고"));
+        classId++;
+        temp.classList.add(new Class(classId, "K-MOOC:동물의행동"));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "목", 10, 0, 10, 30));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 8 김혜빈
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "가상현실과멀티미디어", "신세계관", "월", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "가상현실과멀티미디어", "신세계관", "수", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "자료구조와알고리즘개론", "원격/비대면", "월", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "자료구조와알고리즘개론", "원격/비대면", "목", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인공지능과딥러닝개론", "원격/비대면", "화", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인공지능과딥러닝개론", "원격/비대면", "목", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "정보기술과미래사회"));
+        classId++;
+        temp.classList.add(new Class(classId, "정보기술과미래사회"));
+        classId++;
+        temp.classList.add(new Class(classId, "K-MOOC:아동의신비한언어습득력-이중언어아동"));
+        classId++;
+        temp.classList.add(new Class(classId, "K-MOOC:아동의신비한언어습득력-이중언어아동"));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "목", 11, 30, 12, 0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 9 조민서
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "캡스톤디자인과창업프로젝트B", "공학관", "화", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "캡스톤디자인과창업프로젝트B", "공학관", "금", 14, 0, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "운영체제", "공학관", "월", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "운영체제", "공학관", "수", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "미시경제이론", "포스코관", "수", 15, 30, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "미시경제이론", "포스코관", "금", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "거시경제이론"));
+        classId++;
+        temp.classList.add(new Class(classId, "금융경제학", "포스코관", "월", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "금융경제학", "포스코관", "목", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "인류문명과환경과학"));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "수", 11, 30, 12, 0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 10 장예원
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "모바일인터랙션디자인(캡스톤디자인)", "조형예술관", "월", 9, 30, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "현대영국소설", "신세계관", "화", 9, 30, 11, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "현대영국소설", "신세계관", "금", 11, 0, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "현대시와사회", "ECC", "화", 12, 30, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "현대시와사회", "ECC", "금", 14, 0, 15, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "형태와공간I", "조형예술관", "수", 9, 30, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "브랜드아이덴티티디자인", "조형예술관", "목", 9, 30, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "엔터테인먼트그래픽스", "조형예술관", "목", 17, 0, 20, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "채플", "대강당", "금", 9, 30, 11, 0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+        // 시트 11 허지원
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "정보디자인", "조형예술관", "월", 11, 0, 14, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "타이포그래피1", "조형예술관", "화", 9, 30, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "북아트", "조형예술관", "화", 14, 0, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "한국회화스튜디오3", "조형예술관", "수", 14, 0, 17, 0));
+        classId++;
+        temp.classList.add(new Class(classId, "그래픽디자인", "조형예술관", "목", 9, 30, 12, 30));
+        classId++;
+        temp.classList.add(new Class(classId, "현대수묵1", "조형예술관", "목", 14, 0, 17, 0));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
+
+
+        // 데이터리스트 리턴
+        return result;
+    }
+
+    /*
+    이 아래는 이동난이도 데이터를 생성하여 Map에 넣는 함수
+     */
+    public static Map<List<String>, Move> makeMoveDifficulties () {
+        Map<List<String>, Move> moveDifficulty = new HashMap<>();
+
+        //  - data1~data6을 채점하기 위한 이동난이도 쌍
+        moveDifficulty.put(Arrays.asList("학관", "학관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "ECC"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "공학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "학관"), new Move(false, Difficulty.HIGH));
+        //  - data7(삼와머니 팀원들이 모은 시간표)을 채점하기 위한 이동난이도 쌍
+        moveDifficulty.put(Arrays.asList("ECC", "ECC"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("공학관", "공학관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("신세계관", "신세계관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "조형예술관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("종합과학관", "종합과학관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "포스코관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("ECC", "대강당"), new Move(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("ECC", "신세계관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "조형예술관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "종합과학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "포스코관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "공학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "대강당"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("공학관", "sk텔레콤관(정보관)"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "대강당"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "종합과학관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "포스코관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("대강당", "sk텔레콤관(정보관)"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "ECC"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "공학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("대강당", "신세계관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "조형예술관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("대강당", "종합과학관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("대강당", "포스코관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("대강당", "학관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("신세계관", "ECC"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("신세계관", "대강당"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "포스코관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "조형예술관"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "ECC"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "대강당"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "신세계관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "ECC"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "공학관"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "대강당"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "포스코관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("종합과학관", "학관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "ECC"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("포스코관", "공학관"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "대강당"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "신세계관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "종합과학관"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "학관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "ECC"), new Move(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "대강당"), new Move(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "종합과학관"), new Move(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "포스코관"), new Move(true, Difficulty.LOW));
+
+        // 완성된 이동난이도 Map을 리턴
+        return moveDifficulty;
+
     }
 
     /*
@@ -1295,7 +1673,7 @@ public class Main {
             specialComments.put(i, new SpecialComment(i, contents[i.intValue()], i));
         // 우선순위는 일단 ID와 동일하게 설정하였음
 
-        // 완성된 스페셜 코멘트 목록을 리턴
+        // 완성된 스페셜 코멘트 Map을 리턴
         return specialComments;
     }
 
@@ -1303,7 +1681,7 @@ public class Main {
     이 아래는 테스트용 함수
      */
 
-    // 수업 데이터 생성이 잘 되었는지 테스트하는 함수
+    // 수업 데이터 생성이 잘 되었는지 프린트해보는 함수
     public static void printClasses (ArrayList<Class> list) {
         // 주어진 수업 리스트에 대하여
         for(Class c : list) {
@@ -1319,31 +1697,32 @@ public class Main {
         }
     }
 
-    // 시간표 데이터 생성이 잘 되었는지 테스트하는 함수
+    // 시간표 데이터 생성이 잘 되었는지 프린트해보는 함수
     public static void printTables (ArrayList<Table> list) {
         // 주어진 시간표 리스트에 대하여
         for(Table s : list) {
             // 시간표 ID 출력
             System.out.println("Table ID: " + s.id);
             // 시간표에 포함된 수업들의 ID 출력
-            System.out.print("Class IDs: ");
+            System.out.print("모든 수업의 ID: ");
             for(Class c : s.classList) System.out.print(c.id + " ");
             System.out.println();
-            // 요일별로 수업들의 ID 출력
-            System.out.print("월요일: ");
-            for(Class c : s.monday) System.out.print(c.id + " ");
             System.out.println();
-            System.out.print("화요일: ");
-            for(Class c : s.tuesday) System.out.print(c.id + " ");
+            // 요일별로 수업들의 정보 출력
+            System.out.println("월요일: ");
+            for(Class c : s.monday) System.out.println(c.id + " " + c.className + ", " + c.location + ", " + c.weekday + ", " + c.startH + ":" + c.startM + " ~ " + c.endH + ":" + c.endM);
             System.out.println();
-            System.out.print("수요일: ");
-            for(Class c : s.wednesday) System.out.print(c.id + " ");
+            System.out.println("화요일: ");
+            for(Class c : s.tuesday) System.out.println(c.id + " " + c.className + ", " + c.location + ", " + c.weekday + ", " + c.startH + ":" + c.startM + " ~ " + c.endH + ":" + c.endM);
             System.out.println();
-            System.out.print("목요일: ");
-            for(Class c : s.thursday) System.out.print(c.id + " ");
+            System.out.println("수요일: ");
+            for(Class c : s.wednesday) System.out.println(c.id + " " + c.className + ", " + c.location + ", " + c.weekday + ", " + c.startH + ":" + c.startM + " ~ " + c.endH + ":" + c.endM);
             System.out.println();
-            System.out.print("금요일: ");
-            for(Class c : s.friday) System.out.print(c.id + " ");
+            System.out.println("목요일: ");
+            for(Class c : s.thursday) System.out.println(c.id + " " + c.className + ", " + c.location + ", " + c.weekday + ", " + c.startH + ":" + c.startM + " ~ " + c.endH + ":" + c.endM);
+            System.out.println();
+            System.out.println("금요일: ");
+            for(Class c : s.friday) System.out.println(c.id + " " + c.className + ", " + c.location + ", " + c.weekday + ", " + c.startH + ":" + c.startM + " ~ " + c.endH + ":" + c.endM);
             System.out.println();
             System.out.println();
 

--- a/javacodes/src/Main.java
+++ b/javacodes/src/Main.java
@@ -1457,7 +1457,7 @@ public class Main {
         classId++;
         temp.classList.add(new Class(classId, "K-MOOC:동물의행동"));
         classId++;
-        temp.classList.add(new Class(classId, "채플", "대강당", "목", 10, 0, 10, 30));
+        temp.classList.add(new Class(classId, "채플", "대강당", "월", 10, 0, 10, 30));
 
         temp = addClass(temp, temp.classList);
 

--- a/javacodes/src/Main.java
+++ b/javacodes/src/Main.java
@@ -12,7 +12,7 @@ public class Main {
     static ArrayList<Class> hak;
     // ECC에서 하는 강의들을 담을 리스트
     static ArrayList<Class> ecc;
-    // 공대에서 하는 강의들을 담을 리스트
+    // 공학관에서 하는 강의들을 담을 리스트
     static ArrayList<Class> eng;
     // K-MOOC 강의들을 담을 리스트
     static ArrayList<Class> km;
@@ -29,7 +29,7 @@ public class Main {
         classId = 0L;
 
         // 학관 기준으로 했을 때 다른 건물들과의 이동난이도 및 오르막길 여부 분포가 적절해서, 학관을 중심으로 데이터를 생성했습니다.
-        // 원래 공대 중심으로 하려고 했는데... 공대는 모든 건물과의 이동난이도가 '상'이라서 대신 학관으로 선택했습니다ㅎㅎ...
+        // 원래 공학관 중심으로 하려고 했는데... 공학관은 모든 건물과의 이동난이도가 '상'이라서 대신 학관으로 선택했습니다ㅎㅎ...
 
         // 학관 과목 16개 생성
         hak = hak();
@@ -37,7 +37,7 @@ public class Main {
         // 학관과의 이동난이도가 갈 때 '중', 올 때 '상'인 ECC 과목 3개 생성
         ecc = ecc();
 
-        // 학관과의 이동난이도가 왕복 모두 '상'인 공대 과목 3개 생성
+        // 학관과의 이동난이도가 왕복 모두 '상'인 공학관 과목 3개 생성
         eng = eng();
 
         // K-MOOC 과목 3개 생성
@@ -68,6 +68,9 @@ public class Main {
 
         // 6. K-MOOC 개수 차이에 따른 점수 변동 확인을 위한 데이터리스트
         ArrayList<Table> data6 = dataGen6();
+
+        // 7. 삼와머니 팀원들이 구글 스프레드시트에 모은 실제 시간표들의 데이터리스트
+        ArrayList<Table> data7 = dataGen7();
 
 
         /*
@@ -125,9 +128,9 @@ public class Main {
         Map<List<String>, Move> moveDifficulty = new HashMap<>();
         moveDifficulty.put(Arrays.asList("학관", "학관"), new Move(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("학관", "ECC"), new Move(false, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("학관", "공대"), new Move(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "공학관"), new Move(true, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("ECC", "학관"), new Move(true, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("공대", "학관"), new Move(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "학관"), new Move(false, Difficulty.HIGH));
 
         // 스페셜 코멘트 해시맵 생성
         Map<Long, SpecialComment> specialComments = makeSpecialComments();
@@ -303,28 +306,28 @@ public class Main {
         return result;
     }
 
-    // 공대 과목 3개를 생성하는 함수
+    // 공학관 과목 3개를 생성하는 함수
     public static ArrayList<Class> eng() {
-        // 학관과의 이동난이도가 왕복 모두 '상'인 공대 과목 3개 (수업 6개)
+        // 학관과의 이동난이도가 왕복 모두 '상'인 공학관 과목 3개 (수업 6개)
         ArrayList<Class> result = new ArrayList<>();
 
-        // 학관과목1 의 위치만 공대로 바꾼 것
+        // 학관과목1 의 위치만 공학관로 바꾼 것
         classId++;
-        result.add(new Class(classId, "공대과목1", "공대", "월", 11, 0, 12, 30));
+        result.add(new Class(classId, "공학관과목1", "공학관", "월", 11, 0, 12, 30));
         classId++;
-        result.add(new Class(classId, "공대과목1", "공대", "수", 9, 30, 11, 0));
+        result.add(new Class(classId, "공학관과목1", "공학관", "수", 9, 30, 11, 0));
 
-        // 학관과목3 의 위치만 공대로 바꾼 것
+        // 학관과목3 의 위치만 공학관로 바꾼 것
         classId++;
-        result.add(new Class(classId, "공대과목2", "공대", "월", 14, 0, 15, 30));
+        result.add(new Class(classId, "공학관과목2", "공학관", "월", 14, 0, 15, 30));
         classId++;
-        result.add(new Class(classId, "공대과목2", "공대", "수", 15, 30, 17, 0));
+        result.add(new Class(classId, "공학관과목2", "공학관", "수", 15, 30, 17, 0));
 
-        // 학관과목5 의 위치만 공대로 바꾼 것
+        // 학관과목5 의 위치만 공학관로 바꾼 것
         classId++;
-        result.add(new Class(classId, "공대과목3", "공대", "화", 11, 0, 12, 30));
+        result.add(new Class(classId, "공학관과목3", "공학관", "화", 11, 0, 12, 30));
         classId++;
-        result.add(new Class(classId, "공대과목3", "공대", "목", 12, 30, 14, 0));
+        result.add(new Class(classId, "공학관과목3", "공학관", "목", 12, 30, 14, 0));
 
 
         return result;
@@ -869,7 +872,7 @@ public class Main {
     // 이동난이도 차이에 따른 점수 변동 확인을 위한 데이터리스트를 생성하는 함수
     public static ArrayList<Table> dataGen5 () {
         // 이 함수 내의 모든 시간표는 엑셀 파일의 "기본 시간표 형태"를 따름
-        // "기본 시간표 형태"에서, 1번, 3번, 5번 강의의 강의위치만(학관/ECC/공대) 바꾸어 데이터를 생성하였음
+        // "기본 시간표 형태"에서, 1번, 3번, 5번 강의의 강의위치만(학관/ECC/공학관) 바꾸어 데이터를 생성하였음
         // 즉, 모든 시간표에서 직전직후 수업간 이동은 총 6번
 
         ArrayList<Table> result = new ArrayList<>();
@@ -934,7 +937,7 @@ public class Main {
 
         temp.classList.add(eng.get(0));
         temp.classList.add(eng.get(1));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(2));
         temp.classList.add(hak.get(3));
 
@@ -966,7 +969,7 @@ public class Main {
 
         temp.classList.add(eng.get(2));
         temp.classList.add(eng.get(3));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(6));
         temp.classList.add(hak.get(7));
 
@@ -1038,7 +1041,7 @@ public class Main {
 
         temp.classList.add(eng.get(0));
         temp.classList.add(eng.get(1));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(2));
         temp.classList.add(hak.get(3));
 
@@ -1064,13 +1067,13 @@ public class Main {
 
         temp.classList.add(eng.get(0));
         temp.classList.add(eng.get(1));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(2));
         temp.classList.add(hak.get(3));
 
         temp.classList.add(eng.get(2));
         temp.classList.add(eng.get(3));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(6));
         temp.classList.add(hak.get(7));
 
@@ -1090,19 +1093,19 @@ public class Main {
 
         temp.classList.add(eng.get(0));
         temp.classList.add(eng.get(1));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(2));
         temp.classList.add(hak.get(3));
 
         temp.classList.add(eng.get(2));
         temp.classList.add(eng.get(3));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(6));
         temp.classList.add(hak.get(7));
 
         temp.classList.add(eng.get(4));
         temp.classList.add(eng.get(5));
-        // 공대 <-> 학관 (상 2회)
+        // 공학관 <-> 학관 (상 2회)
         temp.classList.add(hak.get(10));
         temp.classList.add(hak.get(11));
 
@@ -1226,6 +1229,42 @@ public class Main {
 
         // 데이터리스트 리턴
         return result;
+    }
+
+    // 삼와머니 팀원들이 구글 스프레드시트에 모은 실제 시간표들의 데이터리스트를 생성하는 함수
+    public static ArrayList<Table> dataGen7 () {
+        ArrayList<Table> result = new ArrayList<>();
+
+        Table temp;
+
+        // 스프레드시트의 시트 순서대로 추가하였습니다
+
+        // 시트 1 노하은
+        tableId++;
+        temp = new Table(tableId);
+
+        classId++;
+        temp.classList.add(new Class(classId, "인공지능", "공학관"));
+        temp.classList.add(hak.get(1));
+
+        temp.classList.add(hak.get(2));
+        temp.classList.add(hak.get(3));
+
+        temp.classList.add(hak.get(4));
+        temp.classList.add(hak.get(5));
+
+        temp.classList.add(hak.get(6));
+        temp.classList.add(hak.get(7));
+
+        temp.classList.add(hak.get(8));
+        temp.classList.add(hak.get(9));
+
+        temp.classList.add(hak.get(10));
+        temp.classList.add(hak.get(11));
+
+        temp = addClass(temp, temp.classList);
+
+        result.add(temp);
     }
 
     /*

--- a/javacodes/src/SpecialComment.java
+++ b/javacodes/src/SpecialComment.java
@@ -1,0 +1,19 @@
+// 스페셜 코멘트 클래스. 시간표가 해당되는 스페셜 코멘트 중 하나를 뽑아 유형으로 선택하는 알고리즘 개발에 사용함. 따라서 ID, 내용, 우선순위 필드만 있음.
+public class SpecialComment {
+    /*
+    필드
+     */
+    Long specialCommentId;  // ID (PK)
+    String content;         // 내용
+    Long priority;          // 우선순위 (숫자가 적을수록 우위이며, 가장 높은 것은 0. Special comment ID를 0부터 설정하셨길래 안 헷갈리게 우선순위도 0부터로 했습니다)
+
+    /*
+    생성자
+     */
+    public SpecialComment (Long id, String content, Long priority) {
+        this.specialCommentId = id;
+        this.content = content;
+        this.priority = priority;
+    }
+
+}

--- a/javacodes/src/TableTypeAlgo.java
+++ b/javacodes/src/TableTypeAlgo.java
@@ -1,0 +1,31 @@
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+
+// 주어진 시간표의 유형을 판별하는 함수
+public class TableTypeAlgo {
+
+    // 특정 시간표의 스페셜 코멘트 아이디 리스트를 받아와서, DB를 참고하여 우선순위대로 정렬 후, 가장 우선순위가 높은 것의 ID를 리턴
+    public static int tableTypeAlgo (ArrayList<Integer> special, Map<Long, SpecialComment> db) {
+        // Comparator 내부 메소드 오버라이딩을 통해 정렬 방식 정의
+        Comparator<Integer> cp = new Comparator<Integer>() {
+            @Override
+            public int compare(Integer i1, Integer i2) {
+                // DB에서 읽어온 우선순위를 기준으로 내림차순 정렬
+                SpecialComment s1 = db.get(Long.valueOf(i1));
+                SpecialComment s2 = db.get(Long.valueOf(i2));
+                if(s1.priority>s2.priority) return 1;
+                else return -1;
+            }
+        };
+
+        // 정의한 정렬 방식대로 special 리스트를 정렬
+        Collections.sort(special, cp);
+        // 정렬이 잘 되었는지 프린트해보기
+        System.out.println("우선순위를 기준으로 정렬된 special 코멘트 리스트: " + special);
+
+        // 가장 우선순위가 높은 하나의 코멘트의 ID를 리턴
+        return special.get(0);
+    }
+}

--- a/javacodes/src/WeekdayAlgo.java
+++ b/javacodes/src/WeekdayAlgo.java
@@ -111,7 +111,7 @@ public class WeekdayAlgo {
     // 7교시 있는 날 세는 함수
     static void sevenCntAlgo(List<Class> day){
         for (Class c : day) {
-            if (c.startH == 5){
+            if (c.startH == 17){
                 sevenCnt++;
                 return;
             }

--- a/javacodes/src/WeekdayAlgo.java
+++ b/javacodes/src/WeekdayAlgo.java
@@ -176,25 +176,35 @@ public class WeekdayAlgo {
                 maxInARowCnt = Math.max(maxInARowCnt, rowCnt); // 현재까지의 최대 연강 수 저장 
 
                 List<String> locationPair = Arrays.asList(current.location, next.location);
-                move = moveDifficulty.get(locationPair);
 
-                if (move.uphill) {
-                    score.put("uphill", score.getOrDefault("uphill", 0) - 3);
-                    uphillCnt++;
+                // 연속된 두 수업 중 하나가 시간이 정해진 원격/비대면 수업이라면, 오르막길이 아닌 이동난이도 '하'와 동일하게 취급
+                if(current.location.equals("원격/비대면") || next.location.equals("원격/비대면"))
+                    score.put("difficulty", score.getOrDefault("difficulty", 0) + 3);
+
+                // 연속된 두 수업 모두 오프라인 강의라면, 이동난이도 계산
+                else{
+                    move = moveDifficulty.get(locationPair);
+
+                    if (move.uphill) {
+                        score.put("uphill", score.getOrDefault("uphill", 0) - 3);
+                        uphillCnt++;
+                    }
+
+                    switch (move.difficulty) {
+                        case LOW:
+                            score.put("difficulty", score.getOrDefault("difficulty", 0) + 3);
+                            break;
+                        case MEDIUM:
+                            score.put("difficulty", score.getOrDefault("difficulty", 0));
+                            break;
+                        case HIGH:
+                            score.put("difficulty", score.getOrDefault("difficulty", 0) - 3);
+                            highCnt++;
+                            break;
+                    }
+
                 }
 
-                switch (move.difficulty) {
-                    case LOW:
-                        score.put("difficulty", score.getOrDefault("difficulty", 0) + 3);
-                        break;
-                    case MEDIUM:
-                        score.put("difficulty", score.getOrDefault("difficulty", 0));
-                        break;
-                    case HIGH:
-                        score.put("difficulty", score.getOrDefault("difficulty", 0) - 3);
-                        highCnt++;
-                        break;
-                }
             } else {
                 falseCnt++;
                 inARow = false;

--- a/javacodes/src/WeekdayAlgo.java
+++ b/javacodes/src/WeekdayAlgo.java
@@ -177,7 +177,7 @@ public class WeekdayAlgo {
 
                 List<String> locationPair = Arrays.asList(current.location, next.location);
 
-                // 연속된 두 수업 중 하나가 시간이 정해진 원격/비대면 수업이라면, 오르막길이 아닌 이동난이도 '하'와 동일하게 취급
+                // 연속된 두 수업 중 하나라도, 시간이 정해진 원격/비대면 수업이라면, 오르막길이 아닌 이동난이도 '하'와 동일하게 취급
                 if(current.location.equals("원격/비대면") || next.location.equals("원격/비대면"))
                     score.put("difficulty", score.getOrDefault("difficulty", 0) + 3);
 

--- a/javacodes/src/WeekdayAlgo.java
+++ b/javacodes/src/WeekdayAlgo.java
@@ -49,6 +49,8 @@ public class WeekdayAlgo {
             special.add(5); // special comment id 5 (충격) 6시 넘어서 수업 듣는 사람 (진짜 계심)
         if (stayLongCnt >= 3)
             special.add(6); // special comment id 6 이대 지박령을 뵙습니다
+        if(plopCnt > 0)
+            special.add(7); // special comment id 7 퐁당퐁당 수업을 나누자
         if (highCnt >= 3)
             special.add(9); // special comment id 9 이대생인 내가 쉬는 시간에는 치타?
         if (uphillCnt >= 3)


### PR DESCRIPTION
## 새롭게 완성한 기능
시간표 유형 선정 기능 추가를 완료하였습니다.
팀원들이 구글 스프레드시트에 적어준 시간표 데이터를 객체로 만들어주는 dataGen7 함수를 만들었습니다. 팀원들의 데이터는 data7에 들어가도록 해두었습니다.

## 수정한 부분
합의된 건물 명칭에 맞추어, 모든 "공대" 문자열을 "공학관"으로 변경하였습니다.
스페셜 코멘트 "퐁당퐁당 수업을 나누자"에 해당되는지 여부를 판단하는 코드가 누락되어있어, 추가하였습니다.

## 해결한 오류
오류 하나를 해결하였습니다. 이 해결방법이 적절한지에 대한 여러분의 의견이 필요하므로, 알고리즘 팀 페이지의 Trouble Shooting 목록에 제가 추가해둔 "시간이 정해져있는 원격/비대면 강의로 인해 이동난이도 계산 과정에서 에러 발생" 게시글을 읽어주세요!

